### PR TITLE
ZipFileSystem.zipFile made public so one can set zipFile.Password

### DIFF
--- a/src/Platform.VirtualFileSystem.Providers.Zip/ZipFileSystem.cs
+++ b/src/Platform.VirtualFileSystem.Providers.Zip/ZipFileSystem.cs
@@ -10,7 +10,7 @@ namespace Platform.VirtualFileSystem.Providers.Zip
 	public class ZipFileSystem
 		: AbstractFileSystem
 	{
-		internal ZLib.ZipFile zipFile;
+		public ZLib.ZipFile zipFile;
 
 		public override bool SupportsActivityEvents
 		{


### PR DESCRIPTION
ZipFileSystem.zipFile made public so one can set zipFile.Password for protected zips.